### PR TITLE
Small bug-fix: Link to Arduino sketch didn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This circuit uses a simple voltage divider and an Arduino to convert the resulti
 
 ### Arduino Sketch
 
-[Electronics\Arduino\A0_to_TTL\A0_to_TTL.ino](Electronics\Arduino\A0_to_TTL\A0_to_TTL.ino)
+[Electronics/Arduino/A0_to_TTL/A0_to_TTL.ino](Electronics/Arduino/A0_to_TTL/A0_to_TTL.ino)
 
 Threshold value needs to be tuned based on the voltage divider. Write `val` to serial to find the min and max value and choose a fitting threshold.
 


### PR DESCRIPTION
Changing backslash "\" to "/" your direct link to Arduino sketch should work.